### PR TITLE
Fix empty command line arguments (For example a command line preparsed w...

### DIFF
--- a/src/sailfishapp_priv.cpp
+++ b/src/sailfishapp_priv.cpp
@@ -43,11 +43,7 @@ static QString applicationPath()
 {
     QStringList _args = QCoreApplication::arguments();
     QString argv0("");
-<<<<<<< HEAD
     if (_args.count() > 0)
-=======
-    if (_args.count > 0)
->>>>>>> FETCH_HEAD
       argv0 = _args[0];
 
     if (argv0.startsWith("/")) {

--- a/src/sailfishapp_priv.cpp
+++ b/src/sailfishapp_priv.cpp
@@ -41,7 +41,10 @@
 
 static QString applicationPath()
 {
-    QString argv0 = QCoreApplication::arguments()[0];
+    QStringList _args = QCoreApplication::arguments();
+    QString argv0("");
+    if (_args.count() > 0)
+      argv0 = _args[0];
 
     if (argv0.startsWith("/")) {
         // First, try argv[0] if it's an absolute path (needed for booster)


### PR DESCRIPTION
It so happens that parsing the command line with QCommandLineParser might cause the QCoreApplication::arguments() to return an empty list. Basic safety code to handle that case.