### PR TITLE
Fix include path in pkg-config file.

### DIFF
--- a/src/src.pro
+++ b/src/src.pro
@@ -52,7 +52,7 @@ CONFIG += create_pc create_prl no_install_prl
 QMAKE_PKGCONFIG_NAME = sailfishapp
 QMAKE_PKGCONFIG_DESCRIPTION = Sailfish Application Library
 QMAKE_PKGCONFIG_LIBDIR = $$target.path
-QMAKE_PKGCONFIG_INCDIR = $$header.path
+QMAKE_PKGCONFIG_INCDIR = ${prefix}/include/sailfishapp
 QMAKE_PKGCONFIG_DESTDIR = pkgconfig
 
 target.path = $$PREFIX/lib


### PR DESCRIPTION
In the SailfishOS sample application the main header is included with this:

    #include <sailfishapp.h>

The corresponding header file is installed to /usr/include/sailfishapp/sailfishapp.h.

The related snippets in the pc file are these two:

    includedir=${prefix}/include
    Cflags: -I${includedir}

Thus the include does not work. It does work in QtC for some reason (it is set up manually?) but not when built with anything else. Tested with CMake.

To fix this the pkg-config file needs to add the sailfishapp dir to include path.
