### PR TITLE
Build: Stop updating version number manually

### DIFF
--- a/rpm/libsailfishapp.spec
+++ b/rpm/libsailfishapp.spec
@@ -1,5 +1,5 @@
 Name: libsailfishapp
-Version: 1.0.11
+Version: 0
 Release: 1
 Summary: Sailfish Application Library
 Group: Development/Libraries
@@ -46,9 +46,7 @@ This package contains the documentation for %{name}.
 %setup -q
 
 %build
-# Auto-update pkg-config / library version from RPM .spec version
-sed -i -e 's#^VERSION = .*$#VERSION = %{version}#' src/src.pro
-%qmake5
+%qmake5 VERSION=%{version}
 make
 
 %install

--- a/src/src.pro
+++ b/src/src.pro
@@ -32,7 +32,6 @@
 
 TEMPLATE = lib
 TARGET = sailfishapp
-VERSION = 1.0.11
 
 QT += quick qml
 


### PR DESCRIPTION
CI ignores the 'Version' tag by default, and mb2 has the --fix-version
(short form -x) switch to use the version denoted by the latest Git tag.