### PR TITLE
[libsailfishapp] Fix ts files installation with Qt 5.6 in upgrade-2.1.0.

### DIFF
--- a/data/sailfishapp_i18n.prf
+++ b/data/sailfishapp_i18n.prf
@@ -33,22 +33,22 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-TS_FILE = \"$${_PRO_FILE_PWD_}/translations/$${TARGET}.ts\"
+TS_FILE = $${_PRO_FILE_PWD_}/translations/$${TARGET}.ts
 HAVE_TRANSLATIONS = 0
 
 # Translation source directories
 TRANSLATION_SOURCE_CANDIDATES = $${_PRO_FILE_PWD_}/src $${_PRO_FILE_PWD_}/qml
 for(dir, TRANSLATION_SOURCE_CANDIDATES) {
     exists($$dir) {
-        TRANSLATION_SOURCES += \"$$dir\"
+        TRANSLATION_SOURCES += $$dir
     }
 }
 
 # prefix all TRANSLATIONS with the src dir
 # the qm files are generated from the ts files copied to out dir
 for(t, TRANSLATIONS) {
-    TRANSLATIONS_IN  += \"$${_PRO_FILE_PWD_}/$$t\"
-    TRANSLATIONS_OUT += \"$${OUT_PWD}/$$t\"
+    TRANSLATIONS_IN  += $${_PRO_FILE_PWD_}/$$t
+    TRANSLATIONS_OUT += $${OUT_PWD}/$$t
     HAVE_TRANSLATIONS = 1
 }
 
@@ -60,7 +60,7 @@ qm.CONFIG += no_check_exist
 qm.commands += lupdate -noobsolete $${TRANSLATION_SOURCES} -ts $${TS_FILE} $$TRANSLATIONS_IN && \
     mkdir -p translations && \
     [ \"$${OUT_PWD}\" != \"$${_PRO_FILE_PWD_}\" -a $$HAVE_TRANSLATIONS -eq 1 ] && \
-    cp -af $${TRANSLATIONS_IN} \"$${OUT_PWD}/translations\" || :
+    cp -af $${TRANSLATIONS_IN} $${OUT_PWD}/translations || :
 
 sailfishapp_i18n_unfinished {
     TRANSLATE_UNFINISHED =


### PR DESCRIPTION
 Contributes to JB#37887

The quoting confuses recent qmake which, thinking it is not an absolute
path because it does not start with slash, prefixes it with path to
project directory again.

Paths with spaces are not supported on many other places so let's simply
remove the quoting.